### PR TITLE
Add dsh-plugin-hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Every entry links to its canonical GitHub repository, current star count, and in
 | Project | Description | Stars | Referenced by |
 | --- | --- | --- | --- |
 | [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) | A developer-preview agent harness where every capability is a swappable, composable plugin. | [![GitHub stars](https://img.shields.io/github/stars/deepseek-ai/deepseek-harness?style=flat&label=stars)](https://github.com/deepseek-ai/deepseek-harness/stargazers) | <details><summary>1 page</summary><ul><li><a href="https://www.deepseek.com/harness/en/">DeepSeek Harness official overview</a> · <sub>Docs</sub></li></ul></details> |
+| [dsh-plugin-hub](https://github.com/Noob-stupid/dsh-plugin-hub) | DSH plugin manager & marketplace: one-click enable/disable, multi-source market, static index (500+ plugins / 300 skills), skill install/disable, suite one-click assembly, framework upgrade adapter | [![GitHub stars](https://img.shields.io/github/stars/Noob-stupid/dsh-plugin-hub?style=flat&label=stars)](https://github.com/Noob-stupid/dsh-plugin-hub/stargazers) | <details><summary>0 pages</summary><sub>No verified references yet.</sub></details> |
 
 **Taxonomy:** Models & Providers · Tools & Skills · Sessions & Storage · Loops & Scheduling · Runtime & Sandboxes · UI & Clients · Integrations · Developer & Operations
 


### PR DESCRIPTION
﻿## 收录申请：dsh-plugin-hub

[Noob-stupid/dsh-plugin-hub](https://github.com/Noob-stupid/dsh-plugin-hub) — DSH 插件管理面板与市场：

- 一键启用/停用已安装插件（HMR 生效），基础设施保护
- 多源插件市场：GitHub / Gitee 直装 / 自定义搜索源、多源汇总、★ 官方筛选
- 静态索引市场：jsDelivr CDN 分发 500+ 插件 / 300 技能，零 GitHub API 调用
- 技能市场：搜索（agent-skills/claude-skills/dsh-skill）、一键安装/停用/删除、系统保护
- 套装（submodule 聚合仓库）一键装配：bundle 插件 / 技能 / agent 预设 / 普通插件
- 自动收录 CI（每 6 小时刷新索引）、框架升级适配（配置备份 + 补丁重打）
- 已打 dsh-plugin topic

感谢收录！
