### PR TITLE
docs: add contribution guidelines and PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+## What changed
+
+<!-- Name the project or listing being added, updated, or moved. -->
+
+## Why it fits
+
+<!-- Explain how the project is built for DeepSeek Harness and why the category is appropriate. -->
+
+## Checklist
+
+- [ ] I searched existing entries and open pull requests for duplicates.
+- [ ] The project is public, maintained, and linked through its canonical GitHub repository.
+- [ ] I updated both `README.md` and `README.zh-CN.md` with equivalent information.
+- [ ] The entry follows the existing table format and category ordering.
+- [ ] Project, badge, and reference links resolve.
+- [ ] `git diff --check` passes.
+- [ ] I disclosed below whether I maintain or am affiliated with the project.
+
+## Affiliation
+
+<!-- State your relationship to the project, or write "None". -->
+
+See [CONTRIBUTING.md](https://github.com/Zhiyuan-Fan/Awesome-DeepSeek-Harness-Plugins/blob/main/CONTRIBUTING.md) for the complete submission guidance.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,60 @@
+# Contributing
+
+[English](#english) | [简体中文](#简体中文)
+
+## English
+
+Thanks for helping improve this directory. You can open a pull request, or add
+the [`dsh-plugin`](https://github.com/topics/dsh-plugin) topic to your repository
+so the daily curator can discover it.
+
+### Before submitting
+
+- Make sure the project is public, useful, maintained, and clearly built for
+  DeepSeek Harness (DSH).
+- Link to the canonical GitHub repository and describe only features that can be
+  verified from public sources.
+- Search existing entries and open pull requests to avoid duplicate submissions.
+- Choose the category that best matches the project's primary capability.
+- Update both `README.md` and `README.zh-CN.md` with equivalent information.
+- Keep each category sorted by GitHub stars, then by verified reference count.
+- Preserve the existing four-column table format, including the dynamic star
+  badge and verified-reference details.
+
+If you maintain or are affiliated with the submitted project, disclose that in
+the pull request description.
+
+### Validation
+
+Before opening the pull request, check that:
+
+- every project, badge, and reference link resolves;
+- the English and Chinese rows identify the same project and capabilities;
+- Markdown table delimiters and details blocks match neighboring entries; and
+- `git diff --check` reports no whitespace errors.
+
+## 简体中文
+
+感谢你帮助改进本清单。你可以直接提交 Pull Request，也可以为项目仓库添加
+[`dsh-plugin`](https://github.com/topics/dsh-plugin) topic，让每日维护任务发现它。
+
+### 提交前
+
+- 确保项目公开、实用、持续维护，并且明确面向 DeepSeek Harness（DSH）。
+- 链接到项目的规范 GitHub 仓库，只描述可通过公开来源验证的功能。
+- 搜索现有条目和开放的 Pull Request，避免重复提交。
+- 按项目的主要能力选择最合适的分类。
+- 同步更新 `README.md` 与 `README.zh-CN.md`，并保持信息一致。
+- 每个分类先按 GitHub stars、再按已验证引用数量排序。
+- 保持现有四列表格格式，包括动态 star 徽章和已验证引用详情。
+
+如果你是所提交项目的维护者或关联方，请在 Pull Request 描述中披露。
+
+### 校验
+
+提交 Pull Request 前，请确认：
+
+- 项目、徽章和引用链接均可访问；
+- 中英文条目指向同一项目，并描述相同能力；
+- Markdown 表格分隔符和详情块与相邻条目格式一致；
+- `git diff --check` 未报告空白错误。

--- a/README.md
+++ b/README.md
@@ -591,7 +591,7 @@ Projects in each section are ranked by GitHub stars, then by verified reference 
 
 ## Contributing
 
-Open a pull request, or add the [`dsh-plugin`](https://github.com/topics/dsh-plugin) topic to your repository so the curator can find it.
+Open a pull request, or add the [`dsh-plugin`](https://github.com/topics/dsh-plugin) topic to your repository so the curator can find it. See [CONTRIBUTING.md](CONTRIBUTING.md) for the submission criteria, bilingual update requirements, ordering rules, and validation checklist.
 
 ## Maintenance
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -591,7 +591,7 @@
 
 ## 贡献
 
-欢迎提交 Pull Request；也可以为仓库添加 [`dsh-plugin`](https://github.com/topics/dsh-plugin) topic，让维护任务发现它。
+欢迎提交 Pull Request；也可以为仓库添加 [`dsh-plugin`](https://github.com/topics/dsh-plugin) topic，让维护任务发现它。提交标准、双语更新要求、排序规则与校验清单请参阅 [CONTRIBUTING.md](CONTRIBUTING.md)。
 
 ## 维护
 


### PR DESCRIPTION
## What changed

- Add a bilingual `CONTRIBUTING.md` covering inclusion criteria, category selection, bilingual updates, ordering, formatting, affiliation disclosure, and validation.
- Add a pull request template that prompts contributors for project fit, duplicate checks, link validation, bilingual parity, and affiliation.
- Link the new guide from the English and Simplified Chinese README contribution sections.

## Why

The repository currently accepts contributions through a one-line instruction, while recent submissions repeatedly need to explain the same expectations: update both READMEs, preserve the four-column format, follow category ordering, avoid duplicates, and disclose project affiliation. Making these rules explicit should reduce incomplete submissions and reviewer back-and-forth without changing the curated list itself.

## Impact

This is documentation-only. It does not modify any plugin entry or the daily curation data.

## Checks

- Rebased onto the latest `main` (`5a650f6`).
- Confirmed there is no existing contribution guide, pull request template, matching branch, or duplicate open PR.
- `git diff --check origin/main...HEAD`
