### PR TITLE
docs: add DeepSeek Harness Handbook to core resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Every entry links to its canonical GitHub repository, current star count, and in
 | Project | Description | Stars | Referenced by |
 | --- | --- | --- | --- |
 | [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) | A developer-preview agent harness where every capability is a swappable, composable plugin. | [![GitHub stars](https://img.shields.io/github/stars/deepseek-ai/deepseek-harness?style=flat&label=stars)](https://github.com/deepseek-ai/deepseek-harness/stargazers) | <details><summary>1 page</summary><ul><li><a href="https://www.deepseek.com/harness/en/">DeepSeek Harness official overview</a> · <sub>Docs</sub></li></ul></details> |
+| [DeepSeek Harness Handbook](https://github.com/sandbaseai/deepseek-harness-handbook) | Source-backed, Agent-first operator guides for runtime architecture, plugins, MCP, Sessions, sandboxing, and troubleshooting. | [![GitHub stars](https://img.shields.io/github/stars/sandbaseai/deepseek-harness-handbook?style=flat&label=stars)](https://github.com/sandbaseai/deepseek-harness-handbook/stargazers) | <details><summary>1 page</summary><ul><li><a href="https://sandbaseai.github.io/deepseek-harness-handbook/">Handbook homepage</a> · <sub>Docs</sub></li></ul></details> |
 
 **Taxonomy:** Models & Providers · Tools & Skills · Sessions & Storage · Loops & Scheduling · Runtime & Sandboxes · UI & Clients · Integrations · Developer & Operations
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -13,6 +13,7 @@
 | Project | 一句话简介 | Stars | 引用网页 |
 | --- | --- | --- | --- |
 | [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) | 一个将所有能力实现为可替换、可组合插件的开发者预览版智能体 Harness。 | [![GitHub stars](https://img.shields.io/github/stars/deepseek-ai/deepseek-harness?style=flat&label=stars)](https://github.com/deepseek-ai/deepseek-harness/stargazers) | <details><summary>1 个网页</summary><ul><li><a href="https://www.deepseek.com/harness/en/">DeepSeek Harness official overview</a> · <sub>文档</sub></li></ul></details> |
+| [DeepSeek Harness Handbook](https://github.com/sandbaseai/deepseek-harness-handbook) | 面向 Agent、基于来源的运行手册，覆盖运行时架构、插件、MCP、Session、沙箱与故障排查。 | [![GitHub stars](https://img.shields.io/github/stars/sandbaseai/deepseek-harness-handbook?style=flat&label=stars)](https://github.com/sandbaseai/deepseek-harness-handbook/stargazers) | <details><summary>1 个网页</summary><ul><li><a href="https://sandbaseai.github.io/deepseek-harness-handbook/">手册首页</a> · <sub>文档</sub></li></ul></details> |
 
 **分类体系：** 模型与提供商 · 工具与技能 · 会话与存储 · 循环与调度 · 运行时与沙箱 · 界面与客户端 · 集成 · 开发与运维
 


### PR DESCRIPTION
## Summary
- Add the source-backed DeepSeek Harness Handbook to the Core section in English and Simplified Chinese.
- Link to the handbook homepage and its live GitHub Stars badge.
- Keep the entry descriptive and label it as documentation, not a plugin.

Handbook: https://github.com/sandbaseai/deepseek-harness-handbook
Latest release: https://github.com/sandbaseai/deepseek-harness-handbook/releases/tag/v0.5.425