### PR TITLE
docs: add busabase-dsh-plugin

### DIFF
--- a/catalog/plugins/busabase--busabase-dsh-plugin.json
+++ b/catalog/plugins/busabase--busabase-dsh-plugin.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "busabase/busabase-dsh-plugin",
+  "name": "busabase-dsh-plugin",
+  "repository": "https://github.com/busabase/busabase-dsh-plugin",
+  "category": "memory",
+  "description": {
+    "en": "Connects DeepSeek Harness to Busabase for workspace knowledge, structured records, and reviewable ChangeRequests.",
+    "zh": "将 DeepSeek Harness 接入 Busabase，用于工作区知识、结构化记录和可审阅的 ChangeRequest。"
+  },
+  "added": "2026-09-10"
+}


### PR DESCRIPTION
Adds `busabase/busabase-dsh-plugin` as a `memory` catalog entry.

- Connects DeepSeek Harness to Busabase for workspace knowledge and structured records.
- Writes are represented as reviewable ChangeRequests.
- The repository declares `dsh.bundle.patch` and the patch file is committed.
- This PR adds exactly one new `catalog/plugins/*.json` file; generated README projections are intentionally left to the catalog workflow.

Disclosure: I work on Busabase.